### PR TITLE
Introduce some sane defaults for ignore & strip.

### DIFF
--- a/npm-package-buffer.js
+++ b/npm-package-buffer.js
@@ -12,12 +12,17 @@ var events = require('events'),
  */
 var PackageBuffer = module.exports = function PackageBuffer(parser, opts) {
   if (!(this instanceof PackageBuffer)) { return new PackageBuffer(parser, opts); }
+
+  opts = opts || {};
+  opts.strip = opts.strip || 1;
+  opts.maxSize = opts.maxSize || Math.pow(10, 6);
+
   TarBuffer.call(this, parser, opts);
 
   var self = this;
   this.files = {};
   this.on('entry', function (e) {
-    if (e.path === 'package/package.json') {
+    if (e.path === 'package.json') {
       self.package = JSON.parse(e.content);
       return;
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/indexzero/npm-package-buffer",
   "dependencies": {
-    "tar-buffer": "^1.1.0"
+    "tar-buffer": "^1.3.0"
   },
   "devDependencies": {
     "istanbul": "~0.3.17",

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -30,13 +30,13 @@ describe('npm-package-buffer simple', function () {
         assert.ok(!errState);
         assert.equal(typeof buffer.package, 'object');
         assert.deepEqual(Object.keys(buffer.files), [
-          'package/.npmignore',
-          'package/README.md',
-          'package/LICENSE',
-          'package/npm-package-buffer.js',
-          'package/test/simple.test.js',
-          'package/test/fixtures/not-a-tarball.tgz',
-          'package/test/fixtures/npm-package-buffer-0.0.0.tgz'
+          '.npmignore',
+          'README.md',
+          'LICENSE',
+          'npm-package-buffer.js',
+          'test/simple.test.js',
+          'test/fixtures/not-a-tarball.tgz',
+          'test/fixtures/npm-package-buffer-0.0.0.tgz'
         ]);
 
         done();


### PR DESCRIPTION
By default: 
- (1) strip `package/` off all paths _(breaking)_ 
- (2) do not buffer any files above 1MB.
