### PR TITLE
Alias `buffer.package` to `buffer.pkg`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ var buffer = new PackageBuffer(parser)
   .on('end', function () {
     //
     // Log fully read the package.json
+    // aliased to `.pkg` as well.
     //
     console.dir(buffer.package);
+    console.dir(buffer.pkg);
 
     //
     // Log all our files in memory

--- a/npm-package-buffer.js
+++ b/npm-package-buffer.js
@@ -23,7 +23,7 @@ var PackageBuffer = module.exports = function PackageBuffer(parser, opts) {
   this.files = {};
   this.on('entry', function (e) {
     if (e.path === 'package.json') {
-      self.package = JSON.parse(e.content);
+      self.package = self.pkg = JSON.parse(e.content);
       return;
     }
 

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -29,6 +29,8 @@ describe('npm-package-buffer simple', function () {
       .on('end', function () {
         assert.ok(!errState);
         assert.equal(typeof buffer.package, 'object');
+        assert.equal(typeof buffer.pkg, 'object');
+        assert.deepEqual(buffer.package, buffer.pkg);
         assert.deepEqual(Object.keys(buffer.files), [
           '.npmignore',
           'README.md',


### PR DESCRIPTION
`package` is a reserved keyword and causes some issues in strict mode.
